### PR TITLE
Update devise dependency version

### DIFF
--- a/devise_google_authenticator.gemspec
+++ b/devise_google_authenticator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     # removed the following to try and get past this bundle update not finding compatible versions for gem issue
     # 'actionmailer' => '>= 3.0',
     # 'actionmailer' => '~> 3.2',# '>= 3.2.12',
-    'devise'  => '4.6.2',
+    'devise'  => '~> 4.7.0',
     'rotp'    => '>= 1.6',
     'rqrcode' => '>= 0.10.1'
   }.each do |lib, version|

--- a/lib/devise_google_authenticator.rb
+++ b/lib/devise_google_authenticator.rb
@@ -16,7 +16,7 @@ module Devise # :nodoc:
   @@ga_remembertime = 1.month
 
   mattr_accessor :ga_appname
-  @@ga_appname = Rails.application.class.parent_name
+  @@ga_appname = Rails.application.class.module_parent_name
 
   mattr_accessor :ga_bypass_signup
   @@ga_bypass_signup = false


### PR DESCRIPTION
Devise couldn't be updated to the target version as devise_google_authenticator has unmet dependency - 'devise ~> 3.2'. 